### PR TITLE
Update test

### DIFF
--- a/.github/workflows/heatcluster.yml
+++ b/.github/workflows/heatcluster.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: install dependencies
-        run: pip install logging argparse pandas numpy pathlib seaborn matplotlib scipy
+        run: pip install pandas numpy pathlib seaborn matplotlib scipy
       
       - name: test (tab-delimited)
         run: ./HeatCluster.py -i test/small_matrix.csv


### PR DESCRIPTION
I removed `argparse` and `logging` because it looks like those are already installed in the github python environment and it throws errors when reinstalled.